### PR TITLE
route-group-layouts

### DIFF
--- a/my-next-app/src/app/layout.js
+++ b/my-next-app/src/app/layout.js
@@ -21,7 +21,9 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
+        <h1>This is navbar </h1>  
         {children}
+        <h1>This is footer</h1>
       </body>
     </html>
   );

--- a/my-next-app/src/app/layouts/(route_groups_layout)/layout.js
+++ b/my-next-app/src/app/layouts/(route_groups_layout)/layout.js
@@ -1,0 +1,8 @@
+export default function RootLayout({ children }) {
+    return (
+        <div >
+          <h1>This is inner layout   </h1>
+          {children}
+        </div>
+    );
+  }

--- a/my-next-app/src/app/layouts/(route_groups_layout)/login/page.js
+++ b/my-next-app/src/app/layouts/(route_groups_layout)/login/page.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const page = () => {
+  return (
+    <div>Login</div>
+  )
+}
+
+export default page

--- a/my-next-app/src/app/layouts/(route_groups_layout)/signup/page.js
+++ b/my-next-app/src/app/layouts/(route_groups_layout)/signup/page.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const page = () => {
+  return (
+    <div>Signup</div>
+  )
+}
+
+export default page

--- a/my-next-app/src/app/layouts/page.js
+++ b/my-next-app/src/app/layouts/page.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const page = () => {
+  return (
+    <div>Layout page </div>
+  )
+}
+
+export default page


### PR DESCRIPTION
A Route Group is a special folder enclosed in parentheses (()), which can be used to group components and apply layouts or logic across multiple pages. The key benefit of this is that the contents of these folders do not affect the URL structure of the application.